### PR TITLE
slight header change to getgeninfo response

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -40,6 +40,7 @@ def get_gen_info(event_id):
 
     r = make_response(json.dumps(response, cls=CustomJSONEncoder))
     r.headers['Content-Type'] = 'application/json'
+    r.headers.add('Access-Control-Allow-Origin', '*')
     return r
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added 'Access-Control-Allow-Origin' header to the response of getgeninfo/<eventID> to access the response in the plugin